### PR TITLE
bugfix/failing-composer-dependencies/#1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"require": {
 		"php": "^7.3",
-		"codekandis/error-codes-interpreter": "^1.0"
+		"codekandis/code-message-interpreter": "^1"
 	},
 	"require-dev": {
 		"roave/security-advisories": "dev-master",


### PR DESCRIPTION
## Removes

* composer package dependency `codekandis/error-messages-interpreter`

## Adds

* composer package dependency `codekandis/code-message-interpreter` [^1]

## References

* fixes #1